### PR TITLE
Add task count display to dashboard header

### DIFF
--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -258,7 +258,7 @@ export async function dashboardCommand() {
 
     async function render(tasks: Task[], modal?: { lines: string[], width: number, height: number }, stats?: TaskStats) {
         UI.clearScreen();
-        UI.header();
+        UI.header(tasks.length);
 
         // Show search status if active
         if (searchMode) {

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -5,17 +5,22 @@ import { format } from "@std/datetime";
 import { TaskStats } from "./stats.ts";
 
 export const UI = {
-    header() {
+    header(taskCount?: number) {
         const art = `
-    
+
     ██╗      █████╗ ███████╗██╗   ██╗███████╗ █████╗  ███████╗██╗  ██╗
     ██║     ██╔══██╗╚══███╔╝╚██╗ ██╔╝╚══██╔═╝ ██╔══██╗██╔════╝██║ ██╔╝
-    ██║     ███████║  ███╔╝  ╚████╔╝    ██║   ███████║███████╗█████╔╝ 
-    ██║     ██╔══██║ ███╔╝    ╚██╔╝     ██║   ██╔══██║╚════██║██╔═██╗ 
+    ██║     ███████║  ███╔╝  ╚████╔╝    ██║   ███████║███████╗█████╔╝
+    ██║     ██╔══██║ ███╔╝    ╚██╔╝     ██║   ██╔══██║╚════██║██╔═██╗
     ███████╗██║  ██║███████╗   ██║      ██║   ██║  ██║███████║██║  ██╗
     ╚══════╝╚═╝  ╚═╝╚══════╝   ╚═╝      ╚═╝   ╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝`;
         console.log(colors.bold.cyan(art));
-        console.log(colors.dim("          " + new Date().toLocaleDateString("en-US", { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })) + "\n");
+        console.log(colors.dim("          " + new Date().toLocaleDateString("en-US", { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })));
+
+        if (taskCount !== undefined && taskCount > 0) {
+            console.log(colors.dim(`          ${taskCount} task${taskCount !== 1 ? 's' : ''}`));
+        }
+        console.log("");
     },
 
     success(text: string) {


### PR DESCRIPTION
- Modify UI.header() to accept optional taskCount parameter
- Display task count below logo when tasks exist
- Update dashboard render to pass tasks.length to header
- Keep menus clean by not showing count in menu screens